### PR TITLE
Include G4ExtendedMaterial in CrystalProcess

### DIFF
--- a/src/CrystalProcess.cc
+++ b/src/CrystalProcess.cc
@@ -28,6 +28,7 @@
 #include "MaterialExtensionData.hh"
 #include "G4CrystalExtension.hh"
 #include "G4LogicalCrystalVolume.hh"
+#include "G4ExtendedMaterial.hh"
 
 CrystalProcess::
 CrystalProcess(const G4String& aName):


### PR DESCRIPTION
This solves the following compilation error:

```
G4_CRYSTAL_EXAMPLE/src/CrystalProcess.cc:84:44: error: member access into incomplete type 'G4ExtendedMaterial'
        return (MaterialExtensionData*) aEM->RetrieveExtension("ExtendedData");
                                           ^
```